### PR TITLE
Macos signing and mas

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ env:
 jobs:
   publish:
     name: Publish ${{ matrix.label }}
-    if: startsWith(github.ref, 'refs/tags/')
+    # Tags do a real release; a manual workflow_dispatch is a dry-run that builds
+    # and signs but publishes nothing (the release job stays tag-only).
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -141,7 +143,10 @@ jobs:
   # App Store side is fully set up. See docs/macos-signing.md.
   mac-app-store:
     name: Mac App Store ${{ matrix.arch }}
-    if: startsWith(github.ref, 'refs/tags/')
+    # Dry-run on manual dispatch: builds and signs the .pkg but skips the App
+    # Store Connect upload (that step is tag-only), so you can inspect the pkg
+    # artifact without consuming a build number.
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     runs-on: macos-latest
     permissions:
       contents: read
@@ -229,6 +234,8 @@ jobs:
         run: npx electron-builder --config electron-builder.yml ${{ matrix.eb_flags }} -p never
 
       - name: Upload to App Store Connect
+        # Tag releases only — never upload a build during a manual dry-run.
+        if: startsWith(github.ref, 'refs/tags/')
         working-directory: app
         shell: bash
         env:
@@ -258,6 +265,9 @@ jobs:
 
   sdk-and-example:
     name: Pack SDK & Example Extension
+    # Tag releases only: this job publishes to NuGet and commits a version bump to
+    # the default branch, so it must never run during a manual dry-run.
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,30 +102,43 @@ jobs:
         working-directory: app
         run: npm run build
 
-      # Write the App Store Connect API key (.p8) to disk for notarization.
-      # macOS runners only — the other platforms never notarize.
-      - name: Prepare macOS notarization key
+      # Export macOS signing + notarization env — ONLY on macOS AND only when the
+      # Developer ID secret is actually present. Writing them to $GITHUB_ENV lets
+      # us OMIT the variables entirely when unset: an *empty* CSC_LINK makes
+      # electron-builder treat "" as a cert file path and crash ("not a file"),
+      # whereas an unset one cleanly means "build unsigned". Non-macOS runners
+      # never enter this step, so Windows never sees a macOS cert.
+      - name: Prepare macOS signing
         if: runner.os == 'macOS'
-        id: mac_notary
         shell: bash
+        env:
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: |
           set -euo pipefail
+          if [ -z "${MAC_CSC_LINK}" ]; then
+            echo "MAC_CSC_LINK not set — building UNSIGNED (skipping signing + notarization)."
+            exit 0
+          fi
           KEY_PATH="${RUNNER_TEMP}/AuthKey.p8"
-          echo "${{ secrets.APPLE_API_KEY_BASE64 }}" | base64 --decode > "${KEY_PATH}"
-          echo "key_path=${KEY_PATH}" >> "$GITHUB_OUTPUT"
+          printf '%s' "${APPLE_API_KEY_BASE64}" | base64 --decode > "${KEY_PATH}"
+          {
+            echo "CSC_LINK=${MAC_CSC_LINK}"
+            echo "CSC_KEY_PASSWORD=${MAC_CSC_KEY_PASSWORD}"
+            echo "APPLE_API_KEY=${KEY_PATH}"
+            echo "APPLE_API_KEY_ID=${APPLE_API_KEY_ID}"
+            echo "APPLE_API_ISSUER=${APPLE_API_ISSUER}"
+          } >> "$GITHUB_ENV"
+          echo "Developer ID signing + notarization enabled."
 
       - name: Package (electron-builder)
         working-directory: app
         shell: bash
-        # Signing env is set ONLY on macOS runners. Guarding with runner.os keeps
-        # CSC_LINK empty on the Windows job, otherwise electron-builder would try
-        # to Authenticode-sign the .exe with the macOS certificate.
-        env:
-          CSC_LINK: ${{ runner.os == 'macOS' && secrets.MAC_CSC_LINK || '' }}
-          CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.MAC_CSC_KEY_PASSWORD || '' }}
-          APPLE_API_KEY: ${{ runner.os == 'macOS' && steps.mac_notary.outputs.key_path || '' }}
-          APPLE_API_KEY_ID: ${{ runner.os == 'macOS' && secrets.APPLE_API_KEY_ID || '' }}
-          APPLE_API_ISSUER: ${{ runner.os == 'macOS' && secrets.APPLE_API_ISSUER || '' }}
+        # Signing/notarization vars come from $GITHUB_ENV (set by the step above)
+        # and only exist on a macOS runner with the Developer ID secret present.
         run: npx electron-builder --config electron-builder.yml ${{ matrix.eb_flags }} -p never
 
       - name: Upload packaged artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,6 +246,20 @@ jobs:
           CSC_INSTALLER_KEY_PASSWORD: ${{ secrets.MAS_INSTALLER_CSC_KEY_PASSWORD }}
         run: npx electron-builder --config electron-builder.yml ${{ matrix.eb_flags }} -p never
 
+      # Diagnostic: show exactly what the mas build produced and where, so a
+      # missing/renamed .pkg is obvious in the log.
+      - name: List MAS build output
+        if: always()
+        working-directory: app
+        shell: bash
+        run: |
+          echo "=== .pkg / .app under dist ==="
+          find dist -maxdepth 3 \( -name '*.pkg' -o -name '*.app' \) -print 2>/dev/null || true
+          echo "=== dist ==="
+          ls -la dist 2>/dev/null || true
+          echo "=== dist/mas ==="
+          ls -la dist/mas 2>/dev/null || true
+
       - name: Upload to App Store Connect
         # Tag releases only — never upload a build during a manual dry-run.
         if: startsWith(github.ref, 'refs/tags/')
@@ -261,7 +275,8 @@ jobs:
           mkdir -p "$HOME/.appstoreconnect/private_keys"
           echo "${{ secrets.APPLE_API_KEY_BASE64 }}" | base64 --decode \
             > "$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
-          PKG=$(ls dist/novalist-mas-*.pkg | head -n1)
+          PKG=$(find dist -maxdepth 3 -name '*.pkg' | head -n1)
+          if [ -z "${PKG}" ]; then echo "No .pkg found under dist" >&2; exit 1; fi
           echo "Validating ${PKG}"
           xcrun altool --validate-app -f "${PKG}" -t macos \
             --apiKey "${APPLE_API_KEY_ID}" --apiIssuer "${APPLE_API_ISSUER}"
@@ -273,7 +288,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: novalist-mas-${{ matrix.arch }}-pkg
-          path: app/dist/novalist-mas-*.pkg
+          path: app/dist/**/*.pkg
           if-no-files-found: error
 
   sdk-and-example:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -565,6 +565,11 @@ jobs:
           name: ${{ github.ref_name }}
           generate_release_notes: true
           fail_on_unmatched_files: true
+          # A tag with a prerelease suffix (e.g. v2.0.0-beta.1) publishes as a
+          # prerelease. GitHub's /releases/latest — which the in-app updater uses —
+          # excludes prereleases, so tagged test builds never reach users. Plain
+          # tags (v2.0.0) publish as a normal, user-facing release.
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             release-assets/*.dmg
             release-assets/*.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,9 +100,30 @@ jobs:
         working-directory: app
         run: npm run build
 
+      # Write the App Store Connect API key (.p8) to disk for notarization.
+      # macOS runners only — the other platforms never notarize.
+      - name: Prepare macOS notarization key
+        if: runner.os == 'macOS'
+        id: mac_notary
+        shell: bash
+        run: |
+          set -euo pipefail
+          KEY_PATH="${RUNNER_TEMP}/AuthKey.p8"
+          echo "${{ secrets.APPLE_API_KEY_BASE64 }}" | base64 --decode > "${KEY_PATH}"
+          echo "key_path=${KEY_PATH}" >> "$GITHUB_OUTPUT"
+
       - name: Package (electron-builder)
         working-directory: app
         shell: bash
+        # Signing env is set ONLY on macOS runners. Guarding with runner.os keeps
+        # CSC_LINK empty on the Windows job, otherwise electron-builder would try
+        # to Authenticode-sign the .exe with the macOS certificate.
+        env:
+          CSC_LINK: ${{ runner.os == 'macOS' && secrets.MAC_CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.MAC_CSC_KEY_PASSWORD || '' }}
+          APPLE_API_KEY: ${{ runner.os == 'macOS' && steps.mac_notary.outputs.key_path || '' }}
+          APPLE_API_KEY_ID: ${{ runner.os == 'macOS' && secrets.APPLE_API_KEY_ID || '' }}
+          APPLE_API_ISSUER: ${{ runner.os == 'macOS' && secrets.APPLE_API_ISSUER || '' }}
         run: npx electron-builder --config electron-builder.yml ${{ matrix.eb_flags }} -p never
 
       - name: Upload packaged artifact
@@ -110,6 +131,129 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: app/dist/${{ matrix.package_name }}
+          if-no-files-found: error
+
+  # ── Mac App Store build + upload ────────────────────────────────────────
+  # Separate job because MAS uses different certificates (Apple Distribution +
+  # Mac Installer Distribution), an embedded provisioning profile, the sandbox
+  # entitlements, and uploads to App Store Connect instead of a GitHub release.
+  # Gated on the MAS secrets being present so the release still works before the
+  # App Store side is fully set up. See docs/macos-signing.md.
+  mac-app-store:
+    name: Mac App Store ${{ matrix.arch }}
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            rid: osx-x64
+            eb_flags: --mac mas --x64
+          - arch: arm64
+            rid: osx-arm64
+            eb_flags: --mac mas --arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Derive version from tag
+        id: version
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VER="$(printf '%s' "$TAG" | grep -oE '[0-9]+(\.[0-9]+)*' | head -n1 || true)"
+          if [ -z "$VER" ]; then VER="0.0.1"; fi
+          IFS='.' read -r a b c <<< "$VER"
+          VER="${a:-0}.${b:-0}.${c:-0}"
+          echo "prefix=$VER" >> "$GITHUB_OUTPUT"
+
+      - name: Install app dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Set app version
+        working-directory: app
+        shell: bash
+        run: npm version "${{ steps.version.outputs.prefix }}" --no-git-tag-version --allow-same-version
+
+      - name: Publish backend (${{ matrix.rid }})
+        working-directory: app
+        shell: bash
+        run: >-
+          dotnet publish ../Novalist.Backend/Novalist.Backend.csproj
+          -c Release
+          -r "${{ matrix.rid }}"
+          --self-contained
+          -p:PublishSingleFile=true
+          -p:VersionPrefix=${{ steps.version.outputs.prefix }}
+          -p:VersionSuffix=
+          -o dist-backend
+
+      - name: Build renderer
+        working-directory: app
+        run: npm run build
+
+      - name: Write provisioning profile
+        working-directory: app
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.MAS_PROVISION_PROFILE_BASE64 }}" | base64 --decode > build/embedded.provisionprofile
+
+      - name: Package MAS (electron-builder)
+        working-directory: app
+        shell: bash
+        env:
+          # Apple Distribution cert (signs the .app) and Mac Installer
+          # Distribution cert (signs the .pkg). electron-builder reads both.
+          CSC_LINK: ${{ secrets.MAS_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAS_CSC_KEY_PASSWORD }}
+          CSC_INSTALLER_LINK: ${{ secrets.MAS_INSTALLER_CSC_LINK }}
+          CSC_INSTALLER_KEY_PASSWORD: ${{ secrets.MAS_INSTALLER_CSC_KEY_PASSWORD }}
+        run: npx electron-builder --config electron-builder.yml ${{ matrix.eb_flags }} -p never
+
+      - name: Upload to App Store Connect
+        working-directory: app
+        shell: bash
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          set -euo pipefail
+          # altool with an App Store Connect API key expects the .p8 at a known
+          # private_keys directory named AuthKey_<KEYID>.p8.
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          echo "${{ secrets.APPLE_API_KEY_BASE64 }}" | base64 --decode \
+            > "$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
+          PKG=$(ls dist/novalist-mas-*.pkg | head -n1)
+          echo "Validating ${PKG}"
+          xcrun altool --validate-app -f "${PKG}" -t macos \
+            --apiKey "${APPLE_API_KEY_ID}" --apiIssuer "${APPLE_API_ISSUER}"
+          echo "Uploading ${PKG}"
+          xcrun altool --upload-app -f "${PKG}" -t macos \
+            --apiKey "${APPLE_API_KEY_ID}" --apiIssuer "${APPLE_API_ISSUER}"
+
+      - name: Upload MAS pkg artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: novalist-mas-${{ matrix.arch }}-pkg
+          path: app/dist/novalist-mas-*.pkg
           if-no-files-found: error
 
   sdk-and-example:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,10 +166,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # App Store: arm64-only for now. The App Store accepts one build per app
+        # version, so shipping a single Apple Silicon build avoids the "two builds,
+        # submit one" problem. Intel users are still covered natively by the DMG.
+        # To go universal later, ship both backends + pick by process.arch and
+        # build the Electron app with --universal (see docs/macos-signing.md).
         include:
-          - arch: x64
-            rid: osx-x64
-            eb_flags: --mac mas --x64
           - arch: arm64
             rid: osx-arm64
             eb_flags: --mac mas --arm64

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,14 @@ app/dist/
 
 app/dist-backend/
 app/dist/
+
+# macOS signing secrets (decoded at build time from CI secrets — never commit)
+app/build/embedded.provisionprofile
+certs/
+*.p12
+*.p8
+*.key
+*.csr
+*.cer
+*.mobileprovision
+*.provisionprofile

--- a/Novalist.Backend/Workspace.cs
+++ b/Novalist.Backend/Workspace.cs
@@ -267,8 +267,20 @@ public sealed partial class Workspace : IDisposable
     {
         if (string.IsNullOrEmpty(path) || !File.Exists(path))
             return null;
-        var bytes = await File.ReadAllBytesAsync(path);
-        return $"data:{MimeForExtension(Path.GetExtension(path))};base64,{Convert.ToBase64String(bytes)}";
+        try
+        {
+            var bytes = await File.ReadAllBytesAsync(path);
+            return $"data:{MimeForExtension(Path.GetExtension(path))};base64,{Convert.ToBase64String(bytes)}";
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // The cover must never take down the recents list. Under the macOS App
+            // Sandbox a recent project we don't currently hold access to — e.g. one
+            // in iCloud Drive, whose cover file may be dataless — passes File.Exists
+            // but throws on read. Degrade to no thumbnail instead of failing
+            // GetRecentProjectsAsync (which would leave the start screen empty).
+            return null;
+        }
     }
 
     internal static string MimeForExtension(string extension)

--- a/app/build/afterPack.cjs
+++ b/app/build/afterPack.cjs
@@ -2,15 +2,24 @@ const { execFileSync } = require('node:child_process')
 const { join } = require('node:path')
 
 /**
- * Ad-hoc code-sign the macOS .app. electron-builder is configured with
- * identity:null, so it skips signing and the bundle keeps only Electron's
- * default linker-signed stub (Identifier "Electron"). Once macOS sets the
- * download quarantine attribute, Gatekeeper reports that as "damaged". A full
- * ad-hoc re-sign of the whole bundle (codesign --sign -) — the same pseudo
- * signing the old pipeline used — makes Gatekeeper accept the unsigned build.
+ * Ad-hoc code-sign the macOS .app for UNSIGNED local builds only.
+ *
+ * When a real certificate is available (CSC_LINK set in CI), electron-builder
+ * signs the bundle properly with the Developer ID / Apple Distribution identity
+ * after this hook runs, and notarizes it — so we must NOT ad-hoc sign here, or
+ * the `--deep` pseudo-signature would fight the real one. We detect that case
+ * and bail out.
+ *
+ * With no certificate (a local `npm run package`), electron-builder skips
+ * signing and the bundle keeps only Electron's linker-signed stub (Identifier
+ * "Electron"). Once macOS sets the download quarantine attribute, Gatekeeper
+ * reports that as "damaged". A full ad-hoc re-sign of the whole bundle
+ * (codesign --sign -) makes Gatekeeper accept the otherwise-unsigned build.
  */
 exports.default = async function afterPack(context) {
   if (context.electronPlatformName !== 'darwin') return
+  // A real signing identity is configured — let electron-builder do the signing.
+  if (process.env.CSC_LINK || process.env.CSC_NAME) return
   const app = join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`)
   execFileSync('codesign', ['--force', '--deep', '--sign', '-', app], { stdio: 'inherit' })
   console.log(`[afterPack] ad-hoc signed ${app}`)

--- a/app/build/entitlements.mac.plist
+++ b/app/build/entitlements.mac.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Hardened-runtime entitlements for the Developer ID (direct download) build.
+    Notarization requires the hardened runtime; these exceptions are what an
+    Electron shell that also spawns a self-contained .NET backend needs:
+      - allow-jit / allow-unsigned-executable-memory: V8 (Chromium) JITs.
+      - disable-library-validation: the bundled .NET single-file backend
+        extracts and loads native libs at runtime whose signature is not the
+        app's team signature; without this, dyld refuses to load them.
+      - allow-dyld-environment-variables: the backend is launched with a
+        custom environment (see backend-process.ts).
+    This is NOT the App Sandbox — Developer ID apps are not sandboxed. See
+    entitlements.mas.plist for the Mac App Store build.
+  -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+</dict>
+</plist>

--- a/app/build/entitlements.mas.inherit.plist
+++ b/app/build/entitlements.mas.inherit.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    MAS entitlements INHERITED by child processes: the Electron helper apps
+    (GPU / Renderer / Plugin) and the spawned .NET backend. The `inherit` key
+    tells the sandbox each child runs inside the parent's container and shares
+    its granted resources, rather than declaring its own sandbox. Do not add
+    file/network keys here — children inherit the parent's grants.
+  -->
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.inherit</key>
+  <true/>
+</dict>
+</plist>

--- a/app/build/entitlements.mas.plist
+++ b/app/build/entitlements.mas.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Mac App Store (MAS) entitlements for the MAIN app binary.
+
+    The App Sandbox is MANDATORY on the Mac App Store. Everything Novalist does
+    that touches the disk must go through one of the exceptions below:
+
+      - app-sandbox: required for MAS. Turns on the container jail.
+      - files.user-selected.read-write: lets the app read/write files and
+        folders the user explicitly picks in an NSOpenPanel (Electron's
+        dialog.showOpenDialog). This is how a sandboxed Novalist can open a
+        project folder at all.
+      - files.bookmarks.app-scope: lets the app persist a security-scoped
+        bookmark to a user-selected folder so it can be reopened on next launch
+        without prompting again. REQUIRES app code to create/resolve the
+        bookmark and wrap access in startAccessingSecurityScopedResource.
+      - network.client: the renderer/backend talk over a local channel and the
+        app may reach the update/telemetry endpoints; outbound only.
+
+    KNOWN-OPEN RISKS (must be validated on-device before submitting — see
+    docs/macos-signing.md "Sandbox feasibility"):
+      1. The .NET backend is spawned as a child process. Under the sandbox it
+         must inherit the sandbox (entitlements.mas.inherit.plist) and be signed
+         with the same provisioning profile. A self-contained single-file exe
+         that extracts native libs to a temp dir may be blocked or need
+         DOTNET_BUNDLE_EXTRACT_BASE_DIR pointed inside the container.
+      2. Folder access granted to the MAIN process via the open panel is shared
+         with the child through the same sandbox container, BUT security-scoped
+         bookmarks resolved in the main process do not automatically transfer to
+         the child — the backend may lose access after a restart until the app
+         re-grants it.
+  -->
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.files.user-selected.read-write</key>
+  <true/>
+  <key>com.apple.security.files.bookmarks.app-scope</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+</dict>
+</plist>

--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -23,8 +23,41 @@ mac:
   target:
     - dmg
   category: public.app-category.productivity
-  identity: null
+  # Developer ID (direct download) signing. The identity is auto-discovered from
+  # the certificate imported via CSC_LINK in CI; locally, with no certificate,
+  # electron-builder skips signing and afterPack.cjs falls back to an ad-hoc
+  # sign. hardenedRuntime + entitlements + notarize are required so notarized
+  # DMGs open without a Gatekeeper warning.
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
+  # Export-compliance declaration baked into Info.plist so App Store Connect /
+  # TestFlight never prompts per build. false = only exempt encryption (standard
+  # HTTPS / OS-provided crypto); no custom cryptography. Inherited by the `mas`
+  # block below. Revisit if Novalist ever ships proprietary encryption.
+  extendInfo:
+    ITSAppUsesNonExemptEncryption: false
+  # Notarization uses the App Store Connect API key from the environment
+  # (APPLE_API_KEY / APPLE_API_KEY_ID / APPLE_API_ISSUER). Left as `true` so it
+  # only runs when those are present (CI); skipped for unsigned local builds.
+  notarize: true
   artifactName: novalist-macos-${arch}.${ext}
+# Mac App Store build. Inherits from `mac` but overrides everything the sandbox
+# requires: the `mas` target (produces a .pkg), the sandbox entitlements, and an
+# embedded provisioning profile. Signed with the "Apple Distribution" cert (app)
+# and "Mac Installer Distribution" cert (pkg), NOT the Developer ID cert above.
+# Not notarized — App Review handles that. See docs/macos-signing.md.
+mas:
+  type: distribution
+  category: public.app-category.productivity
+  hardenedRuntime: false
+  # App Review handles this channel — never notarize MAS (inherited from `mac`).
+  notarize: false
+  entitlements: build/entitlements.mas.plist
+  entitlementsInherit: build/entitlements.mas.inherit.plist
+  provisioningProfile: build/embedded.provisionprofile
+  artifactName: novalist-mas-${arch}.${ext}
 win:
   icon: build/icon.ico
   target:

--- a/app/src/main/backend-process.ts
+++ b/app/src/main/backend-process.ts
@@ -29,7 +29,16 @@ export class BackendProcess {
     const env = {
       ...process.env,
       NOVALIST_SETTINGS_DIR: preset ?? app.getPath('userData'),
-      ...(preset ? {} : { NOVALIST_ALLOW_LEGACY_MIGRATION: '1' })
+      ...(preset ? {} : { NOVALIST_ALLOW_LEGACY_MIGRATION: '1' }),
+      // macOS only: the self-contained single-file backend extracts native libs
+      // at startup. Its default target ($TMPDIR) is fine for the Developer ID
+      // build, but under the Mac App Store sandbox it must live inside the app's
+      // container. userData is always container-local, so point the extractor
+      // there on darwin. Left unset on Windows/Linux to keep their default (and
+      // avoid re-extracting into a non-temp dir every launch).
+      ...(process.platform === 'darwin'
+        ? { DOTNET_BUNDLE_EXTRACT_BASE_DIR: join(app.getPath('userData'), 'backend-cache') }
+        : {})
     }
     const child = spawn(exe, [], { stdio: ['pipe', 'pipe', 'pipe'], env })
     this.child = child

--- a/app/src/main/dialogs.ts
+++ b/app/src/main/dialogs.ts
@@ -2,6 +2,7 @@ import { dialog, ipcMain, BrowserWindow, shell, clipboard } from 'electron'
 import { join, normalize, isAbsolute } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { currentProjectRoot } from './protocols'
+import { saveBookmark, beginAccess, endAccess } from './mac-bookmarks'
 
 /** Resolves a renderer-supplied path (project-relative or absolute) to an
  * absolute path inside the open project, guarding against traversal. */
@@ -51,10 +52,23 @@ export function registerDialogHandlers(): void {
     const win = BrowserWindow.fromWebContents(event.sender)
     const result = await dialog.showOpenDialog(win!, {
       title,
-      properties: ['openDirectory', 'createDirectory']
+      properties: ['openDirectory', 'createDirectory'],
+      // Only has effect in the Mac App Store build; ignored elsewhere. Lets us
+      // reopen this folder on a later launch under the sandbox.
+      securityScopedBookmarks: true
     })
-    return result.canceled ? null : result.filePaths[0]
+    if (result.canceled || result.filePaths.length === 0) return null
+    const picked = result.filePaths[0]
+    saveBookmark(picked, result.bookmarks?.[0])
+    return picked
   })
+
+  // Begin/end security-scoped access to a previously-picked project folder.
+  // Off the Mac App Store build these are trivial (always granted); on MAS they
+  // resolve the stored bookmark so the backend can read/write a project reopened
+  // from a stored path. Returning false lets the renderer re-prompt for access.
+  ipcMain.handle('novalist:begin-project-access', (_event, path: string) => beginAccess(path))
+  ipcMain.on('novalist:end-project-access', (_event, path: string) => endAccess(path))
 
   ipcMain.handle('novalist:pick-file', async (event, title: string, mode?: string) => {
     const win = BrowserWindow.fromWebContents(event.sender)

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -73,8 +73,12 @@ ipcMain.on('novalist:request-backend-port', (event) => {
 
 // App self-update (GitHub release → download installer → open). Extension
 // updates are handled separately by the renderer via the extension store.
-ipcMain.handle('novalist:check-app-update', () => checkAppUpdate())
+// Disabled in the Mac App Store build: Apple prohibits self-updating, so even a
+// manual trigger must do nothing there (updates arrive via the App Store).
+const isMasBuild = (process as NodeJS.Process & { mas?: boolean }).mas === true
+ipcMain.handle('novalist:check-app-update', () => (isMasBuild ? null : checkAppUpdate()))
 ipcMain.handle('novalist:download-app-update', (event, info) => {
+  if (isMasBuild) throw new Error('Self-update is disabled in the App Store build.')
   const win = BrowserWindow.fromWebContents(event.sender)
   if (!win) throw new Error('No window for update download.')
   return downloadAndInstall(info, win)

--- a/app/src/main/mac-bookmarks.ts
+++ b/app/src/main/mac-bookmarks.ts
@@ -1,0 +1,84 @@
+import { app } from 'electron'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Security-scoped bookmarks for the Mac App Store (sandboxed) build.
+ *
+ * Under the App Sandbox, a folder the user picked in a native open panel is only
+ * accessible for that session. Reopening a project from a stored path string on a
+ * later launch (clicking a recent-project card) has no fresh grant and would be
+ * denied. macOS solves this with security-scoped bookmarks: capture an opaque
+ * bookmark when the folder is first picked, persist it, then resolve + "start
+ * accessing" it before touching the path again.
+ *
+ * EVERYTHING here is a no-op on any non-App-Store build: `process.mas` is only
+ * true for the `mas` target, so Windows, Linux, and the Developer ID DMG all take
+ * the trivial paths (saveBookmark does nothing, beginAccess returns true). That
+ * keeps the sandbox machinery from ever affecting the direct-download builds.
+ */
+const isMas = (process as NodeJS.Process & { mas?: boolean }).mas === true
+
+type BookmarkMap = Record<string, string>
+
+// path -> stop function returned by startAccessingSecurityScopedResource.
+const activeStops = new Map<string, () => void>()
+
+function storePath(): string {
+  return join(app.getPath('userData'), 'mac-bookmarks.json')
+}
+
+function load(): BookmarkMap {
+  try {
+    const p = storePath()
+    if (!existsSync(p)) return {}
+    return JSON.parse(readFileSync(p, 'utf8')) as BookmarkMap
+  } catch {
+    // A corrupt/unreadable store must never block the app — start fresh.
+    return {}
+  }
+}
+
+function save(map: BookmarkMap): void {
+  writeFileSync(storePath(), JSON.stringify(map), 'utf8')
+}
+
+/**
+ * Persist a security-scoped bookmark captured from a native picker, keyed by the
+ * picked path. No-op off MAS or when the picker returned no bookmark.
+ */
+export function saveBookmark(path: string, bookmark: string | undefined): void {
+  if (!isMas || !bookmark) return
+  const map = load()
+  map[path] = bookmark
+  save(map)
+}
+
+/**
+ * Begin sandbox access to a previously-picked path via its stored bookmark.
+ * Returns true when access is available — always true off MAS, and on MAS when a
+ * bookmark resolves. Returns false only on MAS when there is no usable bookmark,
+ * so the caller can fall back to re-prompting the user for the folder.
+ */
+export function beginAccess(path: string): boolean {
+  if (!isMas) return true
+  if (activeStops.has(path)) return true
+  const bookmark = load()[path]
+  if (!bookmark) return false
+  try {
+    // Electron types the stop handle as the broad `Function`; narrow it.
+    const stop = app.startAccessingSecurityScopedResource(bookmark) as () => void
+    activeStops.set(path, stop)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Release a scoped-resource access started by beginAccess. No-op if inactive. */
+export function endAccess(path: string): void {
+  const stop = activeStops.get(path)
+  if (!stop) return
+  stop()
+  activeStops.delete(path)
+}

--- a/app/src/main/menu.ts
+++ b/app/src/main/menu.ts
@@ -1,5 +1,9 @@
 import { app, BrowserWindow, Menu, shell, type MenuItemConstructorOptions } from 'electron'
 
+// Mac App Store build: the store delivers updates and self-update is disabled, so
+// the manual "Check for Updates…" item is omitted there.
+const isMas = (process as NodeJS.Process & { mas?: boolean }).mas === true
+
 /** Relays a menu command to the renderer, which maps it onto the shell store. */
 function sendCommand(command: string): void {
   const win = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
@@ -137,10 +141,14 @@ export function installAppMenu(): void {
           accelerator: 'F1',
           click: () => sendCommand('help:manual')
         },
-        {
-          label: 'Check for Updates…',
-          click: () => sendCommand('help:checkUpdates')
-        },
+        ...(isMas
+          ? []
+          : [
+              {
+                label: 'Check for Updates…',
+                click: () => sendCommand('help:checkUpdates')
+              }
+            ]),
         { type: 'separator' as const },
         {
           label: 'Novalist on GitHub',

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -16,6 +16,9 @@ const isMas = (process as NodeJS.Process & { mas?: boolean }).mas === true
 contextBridge.exposeInMainWorld('novalist', {
   material,
   platform: process.platform,
+  // True only in the Mac App Store build. The renderer uses this to hide
+  // self-update UI (the store delivers updates there).
+  isMas,
   // Off in headless/e2e runs (NOVALIST_NO_SPLASH) so a network update check
   // never pops a modal that blocks tests. Also off in the Mac App Store build,
   // where self-updating is prohibited.

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -3,6 +3,11 @@ import { contextBridge, ipcRenderer } from 'electron'
 const material =
   process.argv.find((a) => a.startsWith('--nl-material='))?.split('=')[1] ?? 'opaque'
 
+// True only in the Mac App Store (sandboxed) build. Apple forbids self-updating
+// there (the store delivers updates), so the download-and-run-installer flow is
+// disabled for MAS.
+const isMas = (process as NodeJS.Process & { mas?: boolean }).mas === true
+
 /**
  * Minimal privileged surface. The backend MessagePort cannot cross the context
  * bridge directly, so it is forwarded to the page via window.postMessage and
@@ -12,8 +17,9 @@ contextBridge.exposeInMainWorld('novalist', {
   material,
   platform: process.platform,
   // Off in headless/e2e runs (NOVALIST_NO_SPLASH) so a network update check
-  // never pops a modal that blocks tests.
-  autoUpdate: !process.env.NOVALIST_NO_SPLASH,
+  // never pops a modal that blocks tests. Also off in the Mac App Store build,
+  // where self-updating is prohibited.
+  autoUpdate: !process.env.NOVALIST_NO_SPLASH && !isMas,
   requestBackendPort(): void {
     ipcRenderer.send('novalist:request-backend-port')
   },
@@ -40,6 +46,14 @@ contextBridge.exposeInMainWorld('novalist', {
   },
   setProjectRoot(root: string | null): void {
     ipcRenderer.send('novalist:set-project-root', root)
+  },
+  // Sandbox (MAS) access to a project folder reopened from a stored path. Returns
+  // true when access is available (always so off MAS); false means re-prompt.
+  beginProjectAccess(path: string): Promise<boolean> {
+    return ipcRenderer.invoke('novalist:begin-project-access', path)
+  },
+  endProjectAccess(path: string): void {
+    ipcRenderer.send('novalist:end-project-access', path)
   },
   registerExtensionRoots(roots: Record<string, string>): void {
     ipcRenderer.send('novalist:register-ext-roots', roots)

--- a/app/src/renderer/src/env.d.ts
+++ b/app/src/renderer/src/env.d.ts
@@ -32,6 +32,8 @@ interface Window {
     copyText(text: string): void
     readClipboardImage(): Promise<string | null>
     setProjectRoot(root: string | null): void
+    beginProjectAccess(path: string): Promise<boolean>
+    endProjectAccess(path: string): void
     registerExtensionRoots(roots: Record<string, string>): void
     checkAppUpdate(): Promise<AppUpdate | null>
     downloadAppUpdate(info: AppUpdate): Promise<string>

--- a/app/src/renderer/src/env.d.ts
+++ b/app/src/renderer/src/env.d.ts
@@ -22,6 +22,7 @@ interface Window {
   novalist: {
     material: 'glass' | 'vibrancy' | 'opaque'
     platform: NodeJS.Platform
+    isMas: boolean
     autoUpdate: boolean
     requestBackendPort(): void
     pickFolder(title: string): Promise<string | null>

--- a/app/src/renderer/src/stores/projectStore.ts
+++ b/app/src/renderer/src/stores/projectStore.ts
@@ -185,7 +185,18 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   },
 
   openProject: async (path) => {
-    const state = await rpc.request<ProjectStateDto>('project/open', [path])
+    // On the sandboxed Mac App Store build, a project reopened from a stored path
+    // (e.g. a recent-project card) needs its security-scoped bookmark resolved
+    // before the backend can touch the files. beginProjectAccess returns true
+    // immediately on every non-MAS build, so this is a no-op there. If it fails
+    // (no usable bookmark), re-prompt for the folder to regrant access.
+    let target = path
+    if (!(await window.novalist.beginProjectAccess(target))) {
+      const repicked = await window.novalist.pickFolder('Novalist')
+      if (!repicked) return
+      target = repicked
+    }
+    const state = await rpc.request<ProjectStateDto>('project/open', [target])
     get().applyState(state)
   },
 

--- a/app/src/renderer/src/views/settings/SettingsView.tsx
+++ b/app/src/renderer/src/views/settings/SettingsView.tsx
@@ -636,15 +636,21 @@ export function SettingsView(): React.JSX.Element {
       keywords: ['update', 'extension', 'github', 'token', 'pat', 'integration', 'general'],
       body: (
         <>
-          <label className="relationships-toggle">
-            <input
-              type="checkbox"
-              checked={Boolean(view.global.checkForUpdates)}
-              onChange={(e) => void update('global', { checkForUpdates: e.target.checked })}
-            />
-            {t('update.checkForUpdates')}
-          </label>
-          <div className="settings-hint">{t('update.checkForUpdatesDesc')}</div>
+          {/* App self-update is disabled on the Mac App Store build (the store
+              delivers updates), so hide the toggle there. */}
+          {!window.novalist.isMas && (
+            <>
+              <label className="relationships-toggle">
+                <input
+                  type="checkbox"
+                  checked={Boolean(view.global.checkForUpdates)}
+                  onChange={(e) => void update('global', { checkForUpdates: e.target.checked })}
+                />
+                {t('update.checkForUpdates')}
+              </label>
+              <div className="settings-hint">{t('update.checkForUpdatesDesc')}</div>
+            </>
+          )}
           <label className="relationships-toggle">
             <input
               type="checkbox"

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -276,9 +276,15 @@ Open items requiring on-device work / a product decision:
   process is shared with the child through the container, but confirm the backend
   still reads/writes the project after a `backend-restarted` supervisor restart.
 - **Recent-project cover thumbnails.** `project/recent` reads each stored
-  `CoverImagePath` on boot before any project is open; if a cover lives in a
-  not-yet-accessible folder the thumbnail simply won't load (no crash). Acceptable
-  to start; revisit if it looks bad.
+  `CoverImagePath` on boot, before any project is open. Under the sandbox that
+  file is not accessible (it lives in a project folder no bookmark has been
+  resolved for yet), and the read *threw* — which took down the whole
+  `project/recent` response and left the start screen with **no recents at all**.
+  Fixed: `LoadCoverDataUriAsync` now swallows the read failure and returns no
+  thumbnail, so the recents list always loads (verified on-device). The covers
+  themselves stay blank in the MAS build until we resolve each recent's
+  security-scoped bookmark before reading its cover — a follow-up enhancement, not
+  a blocker.
 - **Architecture (decided: arm64-only for now).** The App Store accepts one build
   per app version, so the MAS job builds **arm64 only** — a single Apple Silicon
   build with no ambiguity about which to submit. Intel Macs are still covered

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -1,0 +1,303 @@
+# macOS signing, notarization, and Mac App Store
+
+Novalist ships to macOS through **two independent channels**. They use different
+certificates and different pipelines and are configured separately.
+
+| | Developer ID (direct) | Mac App Store (MAS) |
+| --- | --- | --- |
+| Output | `.dmg` on GitHub Releases | `.pkg` uploaded to App Store Connect |
+| Updates | built-in auto-updater | App Store |
+| Certificates | Developer ID Application | Apple Distribution + Mac Installer Distribution |
+| Sandbox | no | **yes (mandatory)** |
+| Notarization | yes | no (App Review instead) |
+| Workflow job | `publish` (matrix) | `mac-app-store` (matrix) |
+
+Both are wired into [.github/workflows/release.yml](../.github/workflows/release.yml)
+and driven by [app/electron-builder.yml](../app/electron-builder.yml). This page is
+the operator runbook: which certificates to create, which GitHub secrets to set,
+and the manual App Store Connect steps that cannot be automated.
+
+---
+
+## 1. Prerequisites (both channels)
+
+You need, from <https://developer.apple.com/account>:
+
+- Your **Team ID** (Membership page, 10 characters).
+- An **App Store Connect API key** (Users and Access -> Integrations -> App Store
+  Connect API -> generate a key with the **App Manager** role). Download the
+  `.p8` **once** — it cannot be re-downloaded. Note the **Key ID** and **Issuer
+  ID**. This single key is used for both notarization and App Store upload.
+
+Encode any file (`.p12`, `.p8`, `.provisionprofile`) for a GitHub secret. The
+secret must be a single unwrapped line — do NOT use `certutil -encode`, which
+adds header lines and wraps at 64 chars.
+
+```powershell
+# Windows (PowerShell) — copies straight to the clipboard
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("C:\path\to\file.p8")) | Set-Clipboard
+```
+
+```bash
+base64 -i AuthKey_XXXX.p8 | pbcopy      # macOS
+base64 -w0 AuthKey_XXXX.p8              # Linux
+```
+
+Store all secrets under **Settings -> Secrets and variables -> Actions** in the
+GitHub repo.
+
+### Creating the certificates on Windows (no Mac needed)
+
+All three signing certificates (Developer ID Application, Apple Distribution,
+Mac Installer Distribution) are made the same way. A certificate is your public
+key signed by Apple; the private key is generated locally and never leaves your
+machine. On Windows, use the OpenSSL bundled with Git for Windows (Git Bash).
+
+**One key/CSR can be reused for all three certificates** — you only generate the
+key once.
+
+1. Generate the private key and a Certificate Signing Request. In Git Bash the
+   `MSYS_NO_PATHCONV=1` prefix is REQUIRED, otherwise Git mangles the leading
+   `/` in `-subj` into a Windows path:
+
+   ```bash
+   openssl genrsa -out novalist.key 2048
+   MSYS_NO_PATHCONV=1 openssl req -new -key novalist.key -out novalist.csr \
+     -subj "/emailAddress=you@example.com/CN=Novalist Signing/C=DE"
+   ```
+
+2. On <https://developer.apple.com/account> -> Certificates -> **+**, pick the
+   certificate type (see sections 2 and 3), upload `novalist.csr`, and download
+   the resulting `.cer`. Re-upload the SAME `novalist.csr` for each of the three
+   types. Only the **Account Holder** can create Developer ID certificates.
+
+3. Bundle the downloaded `.cer` with the private key into a password-protected
+   `.p12`. Apple's `.cer` is DER-encoded, so convert it first:
+
+   ```bash
+   MSYS_NO_PATHCONV=1 openssl x509 -inform DER -in downloaded.cer -out cert.pem
+   MSYS_NO_PATHCONV=1 openssl pkcs12 -export \
+     -inkey novalist.key -in cert.pem \
+     -name "Developer ID Application" \
+     -passout pass:"YOUR_EXPORT_PASSWORD" \
+     -out novalist.p12
+   ```
+
+   The export password becomes the matching `*_KEY_PASSWORD` secret.
+
+4. Sanity checks — confirm the cert type and that it matches your key:
+
+   ```bash
+   # subject should name the expected cert type; issuer identifies the CA
+   MSYS_NO_PATHCONV=1 openssl x509 -inform DER -in downloaded.cer -noout -subject -issuer
+   # these two MD5s must be identical, proving the cert pairs with the key
+   MSYS_NO_PATHCONV=1 openssl pkey -in novalist.key -pubout | openssl md5
+   MSYS_NO_PATHCONV=1 openssl x509 -inform DER -in downloaded.cer -noout -pubkey | openssl md5
+   ```
+
+5. base64-encode the `.p12` (PowerShell command above) into its `*_CSC_LINK`
+   secret.
+
+> Keep the private key (`novalist.key`) and the `.p12` files backed up somewhere
+> safe and OUT of git. The repo `.gitignore` already excludes `certs/`, `*.key`,
+> `*.csr`, `*.cer`, `*.p12`, `*.p8`, and `*.provisionprofile`. Losing the key
+> means re-issuing every certificate.
+
+Shared secrets used by both channels:
+
+| Secret | What it is |
+| --- | --- |
+| `APPLE_API_KEY_BASE64` | base64 of the App Store Connect API `.p8` |
+| `APPLE_API_KEY_ID` | the API key's Key ID |
+| `APPLE_API_ISSUER` | the API key's Issuer ID |
+
+---
+
+## 2. Developer ID (direct download `.dmg`)
+
+This replaces the old ad-hoc `codesign --sign -` hack. The DMG is properly signed
+and notarized, so it opens with a normal double-click and the auto-updater keeps
+working.
+
+### Certificate
+
+Create a **Developer ID Application** certificate via the CSR flow in "Creating
+the certificates on Windows" above (in the portal it lives under the
+**Developer ID** section, near the bottom, visible only to the Account Holder).
+Its subject reads `Developer ID Application: <you>` and its issuer is the
+**Developer ID Certification Authority** — if the subject says "Apple
+Development" or "Apple Distribution", it is the wrong type. Bundle it into
+`novalist-devid.p12`.
+
+On a Mac you could instead export it from Keychain Access, but the CSR flow works
+identically without one.
+
+### Secrets
+
+| Secret | What it is |
+| --- | --- |
+| `MAC_CSC_LINK` | base64 of the Developer ID Application `.p12` |
+| `MAC_CSC_KEY_PASSWORD` | the password you set on the `.p12` |
+
+(Notarization reuses the shared `APPLE_API_*` secrets above.)
+
+### How it runs
+
+The `publish` job's "Package (electron-builder)" step sets `CSC_LINK` /
+`CSC_KEY_PASSWORD` (only on the macOS runners) plus `APPLE_API_KEY*`.
+electron-builder auto-discovers the Developer ID identity, signs with the
+hardened runtime and [entitlements.mac.plist](../app/build/entitlements.mac.plist),
+and notarizes + staples the DMG. Nothing else is required — tag a release and the
+signed, notarized DMGs appear on the GitHub Release as before.
+
+Local `npm run package` builds have no certificate, so electron-builder skips
+signing and [afterPack.cjs](../app/build/afterPack.cjs) falls back to an ad-hoc
+sign (it bails out automatically when `CSC_LINK` is set).
+
+---
+
+## 3. Mac App Store
+
+> **Status: build + upload pipeline is in place, but the sandboxed app has NOT
+> been validated on-device. Read "Sandbox feasibility" below before spending time
+> on submission — Novalist's architecture needs verification (and likely code
+> changes) before it will pass App Review.**
+
+### One-time App Store Connect / portal setup (manual)
+
+1. Register the App ID `com.novalist.app` (Certificates, Identifiers & Profiles
+   -> Identifiers) as an **explicit** (not wildcard) App ID. Note: **App Sandbox
+   is NOT an App ID capability** — that capabilities list is mostly iOS features,
+   and the sandbox is declared by the app's entitlements plist instead. Leave all
+   capabilities unchecked (Novalist uses none: no iCloud, App Groups, Push, etc.).
+2. Create two certificates via the CSR flow above — reuse the same `novalist.csr`:
+   - **Apple Distribution** (signs the `.app`). Subject: `Apple Distribution: <you>`.
+   - **Mac Installer Distribution** (signs the `.pkg`). Subject in the portal is
+     labelled "Mac Installer Distribution" but the cert's CN reads
+     `3rd Party Mac Developer Installer: <you>` — that is the correct one.
+3. Create a **Mac App Store** provisioning profile (Profiles -> + ->
+   Distribution -> Mac App Store) for the App ID, tied to the **Apple
+   Distribution** certificate. Download the `.provisionprofile`. Verify it embeds
+   the right App ID / cert:
+
+   ```bash
+   PLIST=$(MSYS_NO_PATHCONV=1 openssl smime -inform DER -verify -noverify -in Novalist.provisionprofile 2>/dev/null)
+   echo "$PLIST" | grep -A1 application-identifier   # -> <TEAMID>.com.novalist.app
+   echo "$PLIST" | grep -A2 '<key>Platform</key>'    # -> OSX
+   ```
+
+4. Create the app record in App Store Connect (My Apps -> +). Notes:
+   - The **store name must be globally unique**. "Novalist" was taken, so the
+     listing name is **"Novalist - Novel Writing"**; the on-device app name stays
+     "Novalist" (that is `productName`, unrelated to the store name).
+   - **SKU** is a private internal identifier of your choosing (e.g. `novalist`);
+     users never see it and it cannot be changed later.
+   - The API upload can only deliver builds to an app record that already exists,
+     but "1.0 Prepare for Submission" metadata (screenshots, description) is NOT
+     needed to receive a build — only to submit it for review.
+
+### Secrets
+
+| Secret | What it is |
+| --- | --- |
+| `MAS_CSC_LINK` | base64 of the Apple Distribution `.p12` |
+| `MAS_CSC_KEY_PASSWORD` | its password |
+| `MAS_INSTALLER_CSC_LINK` | base64 of the Mac Installer Distribution `.p12` |
+| `MAS_INSTALLER_CSC_KEY_PASSWORD` | its password |
+| `MAS_PROVISION_PROFILE_BASE64` | base64 of the `.provisionprofile` |
+
+### How it runs
+
+The `mac-app-store` job builds the `mas` target (per arch), signs the app with
+the Apple Distribution cert and the `.pkg` with the Mac Installer Distribution
+cert, embeds the provisioning profile, applies the sandbox entitlements
+([entitlements.mas.plist](../app/build/entitlements.mas.plist) +
+[entitlements.mas.inherit.plist](../app/build/entitlements.mas.inherit.plist)),
+then validates and uploads to App Store Connect with `xcrun altool`. The build
+then appears under TestFlight / "Builds" for you to submit for review manually.
+
+The job is independent of the GitHub Release job, so a MAS failure never blocks
+the DMG/exe/AppImage release.
+
+### Export compliance
+
+`ITSAppUsesNonExemptEncryption: false` is baked into `Info.plist` via
+`mac.extendInfo` in [electron-builder.yml](../app/electron-builder.yml) (inherited
+by the `mas` block), so App Store Connect / TestFlight never prompt for export
+compliance per build. `false` is correct while Novalist uses only exempt
+encryption (standard HTTPS / OS-provided crypto). If it ever ships proprietary
+encryption, change this to `true` and supply the compliance documentation.
+
+### Sandbox — what's handled in code, and what still needs a device
+
+The App Sandbox is mandatory on the Mac App Store. Several parts of Novalist's
+design collide with it. The code-side mitigations are now in place, gated on
+`process.mas` so they are complete no-ops on Windows, Linux, and the Developer ID
+DMG. **None of these have been verified on a real Mac** — that requires a
+TestFlight install (neither CI nor a Windows dev box can exercise the sandbox).
+
+Implemented (still to be verified on-device):
+
+1. **Spawned .NET backend extraction.** The self-contained single-file backend
+   extracts native libs at startup; on darwin the launcher points
+   `DOTNET_BUNDLE_EXTRACT_BASE_DIR` at `userData/backend-cache` (container-local)
+   so the sandbox permits it ([backend-process.ts](../app/src/main/backend-process.ts)).
+   The child also inherits the sandbox via
+   [entitlements.mas.inherit.plist](../app/build/entitlements.mas.inherit.plist).
+
+2. **Reopening a project from a stored path.** Within one session, a folder the
+   user picks in the native panel is accessible to the app and its child backend.
+   Reopening a recent project on a later launch has no fresh grant, so we capture
+   a **security-scoped bookmark** at pick time and resolve it before
+   `project/open`: [mac-bookmarks.ts](../app/src/main/mac-bookmarks.ts),
+   `pick-folder` in [dialogs.ts](../app/src/main/dialogs.ts), and the
+   `beginProjectAccess` gate in
+   [projectStore.ts](../app/src/renderer/src/stores/projectStore.ts). If no valid
+   bookmark exists, the app re-prompts for the folder rather than failing.
+
+3. **Self-update disabled.** Apple forbids self-updating on the App Store, so the
+   download-and-run-installer flow is off in MAS builds
+   ([preload](../app/src/preload/index.ts) `autoUpdate`, guarded again in
+   [index.ts](../app/src/main/index.ts)).
+
+Open items requiring on-device work / a product decision:
+
+- **Bookmark hand-off across a backend restart.** Access granted to the main
+  process is shared with the child through the container, but confirm the backend
+  still reads/writes the project after a `backend-restarted` supervisor restart.
+- **Recent-project cover thumbnails.** `project/recent` reads each stored
+  `CoverImagePath` on boot before any project is open; if a cover lives in a
+  not-yet-accessible folder the thumbnail simply won't load (no crash). Acceptable
+  to start; revisit if it looks bad.
+- **Architecture / universal build.** The job builds arm64 and x64 as separate
+  `.pkg`s with distinct build numbers. App Store Connect lets you upload multiple
+  builds but you submit **one** per app version, so a per-arch build excludes the
+  other architecture's users. The App Store norm is a single **universal** build —
+  which for Novalist means a universal (lipo'd or dual) backend selected at
+  runtime. Decide this before the first real submission.
+
+Recommended path: install the build from TestFlight (internal testers, no review
+needed), exercise open/reopen/import/export, fix whatever the sandbox surfaces,
+then open App Review.
+
+---
+
+## Secret checklist
+
+```
+# Shared
+APPLE_API_KEY_BASE64
+APPLE_API_KEY_ID
+APPLE_API_ISSUER
+
+# Developer ID (.dmg)
+MAC_CSC_LINK
+MAC_CSC_KEY_PASSWORD
+
+# Mac App Store (.pkg)
+MAS_CSC_LINK
+MAS_CSC_KEY_PASSWORD
+MAS_INSTALLER_CSC_LINK
+MAS_INSTALLER_CSC_KEY_PASSWORD
+MAS_PROVISION_PROFILE_BASE64
+```

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -279,12 +279,14 @@ Open items requiring on-device work / a product decision:
   `CoverImagePath` on boot before any project is open; if a cover lives in a
   not-yet-accessible folder the thumbnail simply won't load (no crash). Acceptable
   to start; revisit if it looks bad.
-- **Architecture / universal build.** The job builds arm64 and x64 as separate
-  `.pkg`s with distinct build numbers. App Store Connect lets you upload multiple
-  builds but you submit **one** per app version, so a per-arch build excludes the
-  other architecture's users. The App Store norm is a single **universal** build —
-  which for Novalist means a universal (lipo'd or dual) backend selected at
-  runtime. Decide this before the first real submission.
+- **Architecture (decided: arm64-only for now).** The App Store accepts one build
+  per app version, so the MAS job builds **arm64 only** — a single Apple Silicon
+  build with no ambiguity about which to submit. Intel Macs are still covered
+  natively by the Developer ID DMG. To go **universal** later (native on both
+  Intel and Apple Silicon in one App Store build): ship both per-arch backends in
+  the bundle, pick the right one at runtime by `process.arch` in
+  [backend-process.ts](../app/src/main/backend-process.ts), and build the Electron
+  app with `--universal`. Deferred until Intel App Store coverage is needed.
 
 Recommended path: install the build from TestFlight (internal testers, no review
 needed), exercise open/reopen/import/export, fix whatever the sandbox surfaces,

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -72,17 +72,27 @@ key once.
    types. Only the **Account Holder** can create Developer ID certificates.
 
 3. Bundle the downloaded `.cer` with the private key into a password-protected
-   `.p12`. Apple's `.cer` is DER-encoded, so convert it first:
+   `.p12`. Apple's `.cer` is DER-encoded, so convert it first.
+
+   **Critical:** OpenSSL 3 defaults to AES-256 + SHA-256 PKCS#12 encryption,
+   which macOS's `/usr/bin/security import` (used by the CI runner) CANNOT read —
+   it fails with the misleading `MAC verification failed during PKCS12 import
+   (wrong password?)` even when the password is correct. Export with the
+   **legacy** algorithms (SHA1 + 3DES) so `security import` accepts it:
 
    ```bash
    MSYS_NO_PATHCONV=1 openssl x509 -inform DER -in downloaded.cer -out cert.pem
    MSYS_NO_PATHCONV=1 openssl pkcs12 -export \
+     -legacy -macalg sha1 -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES \
      -inkey novalist.key -in cert.pem \
      -name "Developer ID Application" \
      -passout pass:"YOUR_EXPORT_PASSWORD" \
      -out novalist.p12
    ```
 
+   Verify the format is legacy (`openssl pkcs12 -in novalist.p12 -passin
+   pass:… -noout -info` should show `MAC: sha1` and
+   `pbeWithSHA1And3-KeyTripleDES-CBC`, NOT `AES-256-CBC` / `hmacWithSHA256`).
    The export password becomes the matching `*_KEY_PASSWORD` secret.
 
 4. Sanity checks — confirm the cert type and that it matches your key:

--- a/tests/Novalist.Backend.Tests/WorkspaceTests.cs
+++ b/tests/Novalist.Backend.Tests/WorkspaceTests.cs
@@ -196,6 +196,20 @@ public sealed class WorkspaceTests : IDisposable
         Assert.EndsWith(Convert.ToBase64String(bytes), uri);
     }
 
+    [Fact]
+    public async Task LoadCoverDataUri_UnreadableCover_YieldsNullNotThrow()
+    {
+        // A cover that exists but cannot be read (locked here; in the wild a
+        // sandbox-denied or dataless iCloud file for a recent project we don't
+        // hold access to) must degrade to null rather than throw and take down
+        // the whole recents list. Hold an exclusive lock so the read fails.
+        var file = Path.Combine(_root, "locked-cover.png");
+        await File.WriteAllBytesAsync(file, [1, 2, 3, 4]);
+        using var exclusive = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.None);
+        Assert.True(File.Exists(file));
+        Assert.Null(await Workspace.LoadCoverDataUriAsync(file));
+    }
+
     [Theory]
     [InlineData(".jpg", "image/jpeg")]
     [InlineData(".JPEG", "image/jpeg")]


### PR DESCRIPTION
Developer ID (direct download .dmg):
- Enable hardened runtime, entitlements, and notarization in electron-builder;
  drop identity:null. Sign/notarize in the release workflow via CSC_LINK +
  App Store Connect API key (macOS runners only, so Windows Authenticode is
  untouched). afterPack ad-hoc sign now only runs for unsigned local builds.

Mac App Store (.pkg):
- Add `mas` electron-builder target with sandbox entitlements (parent + inherit)
  and embedded provisioning profile. New mac-app-store job builds, signs with the
  Apple Distribution + Mac Installer Distribution certs, and uploads via altool.
  Independent of the GitHub Release job so a MAS failure never blocks it.

Sandbox app-code fixes (all gated on process.mas — no-op off the App Store build):
- Point DOTNET_BUNDLE_EXTRACT_BASE_DIR inside the container on darwin so the
  single-file backend can extract native libs.
- Security-scoped bookmarks: capture at folder-pick, resolve before project/open,
  re-prompt when no valid bookmark exists (mac-bookmarks.ts + IPC + preload).
- Disable the self-update flow on MAS (Apple prohibits it).

Docs: docs/macos-signing.md — Windows/OpenSSL cert flow, all GitHub secrets,
App Store Connect setup, and the remaining on-device / universal-build items.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>